### PR TITLE
fix(folders): show undecryptable folders instead of hiding them

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -1137,13 +1137,13 @@ private fun InboxWithDrawer(nav_controller: NavHostController) {
         ?: ""
 
     val api_folders = settings_state.labels
-        .filter { !it.is_system && !it.encrypted_name.isNullOrBlank() }
+        .filter { !it.is_system }
         .filter { it.folder_type == "folder" || it.folder_type == "custom" }
-        .filter { !looks_encrypted(it.encrypted_name) }
         .map { label ->
+            val readable_name = label.encrypted_name?.takeIf { it.isNotBlank() && !looks_encrypted(it) }
             drawer_folder_item(
                 id = label.label_token,
-                label = label.encrypted_name.orEmpty(),
+                label = readable_name ?: drawer_context.getString(R.string.folder_decrypt_failed),
                 icon = Icons.Outlined.Folder,
                 count = label.item_count?.toInt() ?: 0,
             )

--- a/app/src/main/kotlin/org/astermail/android/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/astermail/android/settings/SettingsViewModel.kt
@@ -1239,8 +1239,24 @@ class SettingsViewModel @Inject constructor(
                 }
                 val still_all_failed = response.labels.any { !it.encrypted_name.isNullOrBlank() } &&
                     decrypted.all { it.encrypted_name.isNullOrBlank() }
+                if (org.astermail.android.BuildConfig.DEBUG) {
+                    val decrypt_failed = response.labels.indices.count { i ->
+                        !response.labels[i].encrypted_name.isNullOrBlank() &&
+                            decrypted[i].encrypted_name.isNullOrBlank()
+                    }
+                    android.util.Log.i(
+                        "SettingsVM",
+                        "load_labels received=${response.labels.size} decrypt_failed=$decrypt_failed " +
+                            "all_failed=$still_all_failed identity_key=${session_key_store.get_identity_key() != null}",
+                    )
+                }
                 if (still_all_failed) {
-                    _state.value = _state.value.copy(is_loading = false)
+                    val had_readable_labels = _state.value.labels.any { !it.encrypted_name.isNullOrBlank() }
+                    _state.value = if (had_readable_labels) {
+                        _state.value.copy(is_loading = false)
+                    } else {
+                        _state.value.copy(labels = decrypted, is_loading = false)
+                    }
                     return@launch
                 }
                 val server_tokens = decrypted.map { it.label_token }.toSet()
@@ -1260,6 +1276,7 @@ class SettingsViewModel @Inject constructor(
                     is_loading = false,
                 )
             } catch (t: Throwable) {
+                if (org.astermail.android.BuildConfig.DEBUG) android.util.Log.w("SettingsVM", "load_labels failed", t)
                 _state.value = _state.value.copy(
                     is_loading = false,
                     error = t.message ?: context.getString(R.string.something_went_wrong),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -571,6 +571,7 @@
     <string name="drawer_labels">Labels</string>
     <string name="drawer_aliases">Aliases</string>
     <string name="no_folders_yet">No folders yet</string>
+    <string name="folder_decrypt_failed">Folder (decryption failed)</string>
     <string name="no_labels_yet">No labels yet</string>
     <string name="no_aliases_yet">No aliases yet</string>
     <string name="create_folder">Create Folder</string>


### PR DESCRIPTION
## Heads-up: not a confirmed bug fix

The reported issue ("all my folders from previously is gone in the app") **could not be reproduced** on retest - folders decrypted and listed normally. This PR is **defensive hardening only and may be redundant**. Reviewers should weigh it on those terms.

## What it changes

Previously, a folder whose name failed to decrypt (for example after a key rotation when legacy keys aren't available) was silently dropped in two places:

- the drawer folder filter discarded any folder with a null/empty/looks-encrypted name;
- `load_labels` early-returned to an empty list with no error on total decryption failure.

The combined effect would look like data loss even though the folders still exist server-side.

### After

- Undecryptable folders are shown with a `Folder (decryption failed)` label instead of disappearing, so it's clear the data still exists and the problem is a key/decryption issue.
- `load_labels` no longer discards folders when there is no prior good data; the existing anti-wipe guard against transient decrypt failures is preserved.
- Adds debug-only counts logging to `load_labels` (`received` / `decrypt_failed` / `all_failed` / `identity_key`) for on-device diagnosis. No folder names, tokens, or ciphertext are logged.

## Testing

Built (`assembleFdroidDebug`) and installed on-device. Logging confirmed: `load_labels received=8 decrypt_failed=0 all_failed=false identity_key=true`, and folders displayed normally (no fallback entries), consistent with the bug not reproducing.