### PR TITLE
ci: always remove decoded keystore from runner

### DIFF
--- a/.github/workflows/release_fdroid.yml
+++ b/.github/workflows/release_fdroid.yml
@@ -43,6 +43,10 @@ jobs:
           "$apksigner" verify --print-certs Aster-Mail-fdroid.apk
           rm -f release.jks
 
+      - name: cleanup keystore
+        if: always()
+        run: rm -f release.jks
+
       - uses: actions/upload-artifact@v4
         with:
           name: fdroid-signed


### PR DESCRIPTION
Follow-up hardening to the fdroid release-signing workflow (PR #8).

Adds an `if: always()` cleanup step so the base64-decoded `release.jks` is removed
from the runner even if `apksigner sign` fails before the inline `rm`.

Defense-in-depth only - not a leak. The runner is ephemeral and the keystore is
never uploaded as an artifact (only the signed APK is), so there is no exposure
today; this just guarantees removal on the failure path too.