### PR TITLE
refactor(a11y): remove color vision filter setting

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -64,10 +64,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -245,7 +242,6 @@ private fun AsterRoot() {
     val text_spacing by theme_vm.text_spacing.collectAsStateWithLifecycle()
     val underline_links by theme_vm.underline_links.collectAsStateWithLifecycle()
     val dyslexia_font by theme_vm.dyslexia_font.collectAsStateWithLifecycle()
-    val color_vision by theme_vm.color_vision.collectAsStateWithLifecycle()
     val resolved_mode = when (mode_state) {
         ThemeMode.system -> AsterThemeMode.system
         ThemeMode.light -> AsterThemeMode.light
@@ -259,7 +255,6 @@ private fun AsterRoot() {
         text_spacing = text_spacing,
         underline_links = underline_links,
         dyslexia_font = dyslexia_font,
-        color_vision = color_vision,
     )
     val dyslexia_family = if (dyslexia_font) {
         FontFamily(Font(R.font.opendyslexic_regular, FontWeight.Normal))
@@ -284,58 +279,13 @@ private fun AsterRoot() {
             local_accessibility provides a11y,
         ) {
             val colors = AsterMaterial.colors
-            val vision_modifier = color_vision_modifier(color_vision)
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(colors.bg_primary)
-                    .then(vision_modifier),
+                    .background(colors.bg_primary),
             ) {
                 AsterNavHost()
             }
-        }
-    }
-}
-
-private fun color_vision_modifier(mode: String): Modifier {
-    if (mode == "none") return Modifier
-    val values = when (mode) {
-        "protanopia" -> floatArrayOf(
-            0.567f, 0.433f, 0f, 0f, 0f,
-            0.558f, 0.442f, 0f, 0f, 0f,
-            0f, 0.242f, 0.758f, 0f, 0f,
-            0f, 0f, 0f, 1f, 0f,
-        )
-        "deuteranopia" -> floatArrayOf(
-            0.625f, 0.375f, 0f, 0f, 0f,
-            0.7f, 0.3f, 0f, 0f, 0f,
-            0f, 0.3f, 0.7f, 0f, 0f,
-            0f, 0f, 0f, 1f, 0f,
-        )
-        "tritanopia" -> floatArrayOf(
-            0.95f, 0.05f, 0f, 0f, 0f,
-            0f, 0.433f, 0.567f, 0f, 0f,
-            0f, 0.475f, 0.525f, 0f, 0f,
-            0f, 0f, 0f, 1f, 0f,
-        )
-        "achromatopsia" -> floatArrayOf(
-            0.299f, 0.587f, 0.114f, 0f, 0f,
-            0.299f, 0.587f, 0.114f, 0f, 0f,
-            0.299f, 0.587f, 0.114f, 0f, 0f,
-            0f, 0f, 0f, 1f, 0f,
-        )
-        else -> return Modifier
-    }
-    val paint = android.graphics.Paint().apply {
-        colorFilter = android.graphics.ColorMatrixColorFilter(android.graphics.ColorMatrix(values))
-    }
-    return Modifier.drawWithContent {
-        drawIntoCanvas { canvas ->
-            canvas.nativeCanvas.saveLayer(null, paint)
-        }
-        drawContent()
-        drawIntoCanvas { canvas ->
-            canvas.nativeCanvas.restore()
         }
     }
 }
@@ -1118,7 +1068,6 @@ private fun InboxWithDrawer(nav_controller: NavHostController) {
         theme_vm_inbox.set_text_spacing(prefs.text_spacing)
         theme_vm_inbox.set_underline_links(prefs.underline_links)
         theme_vm_inbox.set_dyslexia_font(prefs.dyslexia_font)
-        theme_vm_inbox.set_color_vision(prefs.color_vision)
         theme_vm_inbox.set_text_size_from_key(prefs.font_size_scale)
     }
 

--- a/app/src/main/kotlin/org/astermail/android/ui/settings/detail/accessibility_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/settings/detail/accessibility_screen.kt
@@ -138,7 +138,6 @@ fun AccessibilityScreen(
     LaunchedEffect(Unit) { vm.load_preferences() }
 
     var font_size by remember { mutableStateOf("default") }
-    var color_vision by remember { mutableStateOf("none") }
     var high_contrast by remember { mutableStateOf(false) }
     var reduce_transparency by remember { mutableStateOf(false) }
     var underline_links by remember { mutableStateOf(false) }
@@ -154,7 +153,6 @@ fun AccessibilityScreen(
         if (prefs != null && !prefs_loaded) {
             prefs_loaded = true
             font_size = prefs.font_size_scale
-            color_vision = prefs.color_vision
             high_contrast = prefs.high_contrast
             reduce_transparency = prefs.reduce_transparency
             underline_links = prefs.underline_links
@@ -171,7 +169,6 @@ fun AccessibilityScreen(
             theme_vm.set_text_spacing(prefs.text_spacing)
             theme_vm.set_underline_links(prefs.underline_links)
             theme_vm.set_dyslexia_font(prefs.dyslexia_font)
-            theme_vm.set_color_vision(prefs.color_vision)
         }
     }
 
@@ -180,7 +177,6 @@ fun AccessibilityScreen(
         vm.save_preferences(
             base.copy(
                 font_size_scale = font_size,
-                color_vision = color_vision,
                 high_contrast = high_contrast,
                 reduce_transparency = reduce_transparency,
                 underline_links = underline_links,
@@ -257,27 +253,6 @@ fun AccessibilityScreen(
                     info_title = stringResource(R.string.underline_links_info_title),
                     info_description = stringResource(R.string.underline_links_info_desc),
                 ) { underline_links = it; theme_vm.set_underline_links(it); save_trigger++ }
-            }
-
-            v_gap(AsterSpacing.lg)
-
-            // ── Color Vision ───────────────────────────────────────────────────
-            section_label(stringResource(R.string.color_vision))
-            AsterCard(modifier = Modifier.fillMaxWidth()) {
-                listOf(
-                    "none" to stringResource(R.string.color_vision_none),
-                    "protanopia" to stringResource(R.string.color_vision_protanopia),
-                    "deuteranopia" to stringResource(R.string.color_vision_deuteranopia),
-                    "tritanopia" to stringResource(R.string.color_vision_tritanopia),
-                    "achromatopsia" to stringResource(R.string.color_vision_achromatopsia),
-                ).forEachIndexed { i, (id, label) ->
-                    access_option_row(label, color_vision == id) {
-                        color_vision = id
-                        theme_vm.set_color_vision(id)
-                        save_trigger++
-                    }
-                    if (i < 4) AsterDivider(modifier = Modifier)
-                }
             }
 
             v_gap(AsterSpacing.lg)

--- a/app/src/main/kotlin/org/astermail/android/ui/theme/ThemeController.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/theme/ThemeController.kt
@@ -38,7 +38,6 @@ data class AccessibilityState(
     val text_spacing: Boolean = false,
     val underline_links: Boolean = false,
     val dyslexia_font: Boolean = false,
-    val color_vision: String = "none",
 )
 
 @HiltViewModel
@@ -55,7 +54,6 @@ class ThemeViewModel @Inject constructor(
     val text_spacing: StateFlow<Boolean> = theme_store.text_spacing
     val underline_links: StateFlow<Boolean> = theme_store.underline_links
     val dyslexia_font: StateFlow<Boolean> = theme_store.dyslexia_font
-    val color_vision: StateFlow<String> = theme_store.color_vision
     val onboarding_seen: StateFlow<Boolean> = theme_store.onboarding_seen
 
     fun set_mode(mode: ThemeMode) = theme_store.set_theme_mode(mode)
@@ -69,7 +67,6 @@ class ThemeViewModel @Inject constructor(
     fun set_text_spacing(v: Boolean) = theme_store.set_text_spacing(v)
     fun set_underline_links(v: Boolean) = theme_store.set_underline_links(v)
     fun set_dyslexia_font(v: Boolean) = theme_store.set_dyslexia_font(v)
-    fun set_color_vision(v: String) = theme_store.set_color_vision(v)
     fun mark_onboarding_seen() = theme_store.set_onboarding_seen(true)
 }
 

--- a/core-storage/src/main/kotlin/org/astermail/android/storage/ThemeStore.kt
+++ b/core-storage/src/main/kotlin/org/astermail/android/storage/ThemeStore.kt
@@ -64,7 +64,6 @@ class ThemeStore(context: Context) {
     private val key_text_spacing = booleanPreferencesKey("text_spacing")
     private val key_underline_links = booleanPreferencesKey("underline_links")
     private val key_dyslexia_font = booleanPreferencesKey("dyslexia_font")
-    private val key_color_vision = stringPreferencesKey("color_vision")
     private val key_onboarding_seen = booleanPreferencesKey("onboarding_seen")
 
     val theme_mode: StateFlow<ThemeMode> = app_context.theme_data_store.data
@@ -106,10 +105,6 @@ class ThemeStore(context: Context) {
     val dyslexia_font: StateFlow<Boolean> = app_context.theme_data_store.data
         .map { prefs -> prefs[key_dyslexia_font] ?: false }
         .stateIn(scope, SharingStarted.Eagerly, false)
-
-    val color_vision: StateFlow<String> = app_context.theme_data_store.data
-        .map { prefs -> prefs[key_color_vision] ?: "none" }
-        .stateIn(scope, SharingStarted.Eagerly, "none")
 
     val onboarding_seen: StateFlow<Boolean> = app_context.theme_data_store.data
         .map { prefs -> prefs[key_onboarding_seen] ?: false }
@@ -159,10 +154,6 @@ class ThemeStore(context: Context) {
 
     fun set_dyslexia_font(enabled: Boolean) {
         scope.launch { app_context.theme_data_store.edit { it[key_dyslexia_font] = enabled } }
-    }
-
-    fun set_color_vision(mode: String) {
-        scope.launch { app_context.theme_data_store.edit { it[key_color_vision] = mode } }
     }
 
     fun set_onboarding_seen(seen: Boolean) {


### PR DESCRIPTION
Removes the color vision filter setting and its full-app color-matrix modifier. The synced preference field is kept inert to avoid a schema change.