### PR TITLE
fix(storage): 16 KB page support via sqlcipher-android (0.6.72)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "org.astermail.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 78
-        versionName = "0.6.71"
+        versionCode = 79
+        versionName = "0.6.72"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
@@ -125,7 +125,7 @@ dependencies {
 
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
-    implementation("net.zetetic:android-database-sqlcipher:4.5.4")
+    implementation("net.zetetic:sqlcipher-android:4.16.0")
     implementation("androidx.sqlite:sqlite:2.4.0")
 
     implementation(libs.work.runtime.ktx)

--- a/app/src/main/kotlin/org/astermail/android/di/StorageModule.kt
+++ b/app/src/main/kotlin/org/astermail/android/di/StorageModule.kt
@@ -91,10 +91,10 @@ object StorageModule {
         context: Context,
         meta: SharedPreferences,
     ): AsterDatabase {
-        net.sqlcipher.database.SQLiteDatabase.loadLibs(context)
+        System.loadLibrary("sqlcipher")
         val builder = Room.databaseBuilder(context, AsterDatabase::class.java, db_name)
         builder.openHelperFactory(
-            net.sqlcipher.database.SupportFactory(db_passphrase(meta), null, false),
+            net.zetetic.database.sqlcipher.SupportOpenHelperFactory(db_passphrase(meta), null, false),
         )
         builder.fallbackToDestructiveMigration()
         val db = builder.build()


### PR DESCRIPTION
Migrates SQLCipher to the new net.zetetic:sqlcipher-android:4.16.0 artifact whose native libs are 16 KB page aligned, fixing the Play Console error 'Your app does not support 16 KB memory page sizes' (old android-database-sqlcipher:4.5.4 shipped 4 KB-aligned libsqlcipher.so).

- swap dependency to sqlcipher-android:4.16.0
- SupportFactory -> SupportOpenHelperFactory (new package net.zetetic.database.sqlcipher)
- explicit System.loadLibrary("sqlcipher") (new artifact does not auto-load)
- bump versionCode 79 / versionName 0.6.72

Verified on emulator: all 64-bit native libs now 0x4000 aligned; full login + vault decrypt + mail decryption + encrypted cache write confirmed working.