### PR TITLE
fix(android): render account avatars in drawer header and switcher

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/ui/drawer/drawer_content.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/drawer/drawer_content.kt
@@ -124,9 +124,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.SubcomposeAsyncImage
-import coil.compose.SubcomposeAsyncImageContent
-import coil.compose.AsyncImagePainter
 import org.astermail.android.ui.mail.SenderAvatar
 import org.astermail.android.ui.mail.avatar_colors_for
 import org.astermail.android.ui.mail.initial_for
@@ -351,8 +348,12 @@ fun DrawerContent(
                 .verticalScroll(rememberScrollState())
                 .padding(top = AsterSpacing.md),
         ) {
+            val current_account = accounts.firstOrNull { it.id == current_account_id }
             workspace_header(
                 current_address = current_workspace,
+                account_email = current_account?.email ?: user_email,
+                account_name = current_account?.display_name.orEmpty(),
+                profile_picture = current_account?.profile_picture,
                 on_click = {
                     on_open_workspace_sheet()
                     show_workspace_sheet = true
@@ -993,31 +994,12 @@ private fun workspace_switcher_sheet(
                         .padding(horizontal = AsterSpacing.sm, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (!account.profile_picture.isNullOrBlank()) {
-                        SubcomposeAsyncImage(
-                            model = account.profile_picture,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .size(32.dp)
-                                .clip(CircleShape),
-                        ) {
-                            when (painter.state) {
-                                is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
-                                else -> SenderAvatar(
-                                    email = account.email,
-                                    name = display,
-                                    size = 32.dp,
-                                )
-                            }
-                        }
-                    } else {
-                        SenderAvatar(
-                            email = account.email,
-                            name = display,
-                            size = 32.dp,
-                        )
-                    }
+                    SenderAvatar(
+                        email = account.email,
+                        name = display,
+                        size = 32.dp,
+                        profile_picture_url = account.profile_picture,
+                    )
                     Spacer(Modifier.width(AsterSpacing.md))
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
@@ -1107,7 +1089,13 @@ private fun workspace_switcher_sheet(
 }
 
 @Composable
-private fun workspace_header(current_address: String, on_click: () -> Unit) {
+private fun workspace_header(
+    current_address: String,
+    account_email: String,
+    account_name: String,
+    profile_picture: String?,
+    on_click: () -> Unit,
+) {
     val colors = AsterMaterial.colors
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
@@ -1118,13 +1106,12 @@ private fun workspace_header(current_address: String, on_click: () -> Unit) {
                 .testTag("workspace_switcher"),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Image(
-                painter = painterResource(R.drawable.aster_favicon),
-                contentDescription = stringResource(R.string.app_name),
-                contentScale = ContentScale.Fit,
-                modifier = Modifier
-                    .size(28.dp)
-                    .testTag("account_avatar"),
+            SenderAvatar(
+                email = account_email,
+                name = account_name,
+                size = 28.dp,
+                profile_picture_url = profile_picture,
+                modifier = Modifier.testTag("account_avatar"),
             )
             Spacer(Modifier.width(10.dp))
             Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/sender_avatar.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/sender_avatar.kt
@@ -111,7 +111,7 @@ fun SenderAvatar(
         val (bg_fb, fg_fb) = avatar_colors_for(seed_fb)
         var loaded_pp by remember(profile_picture_url) { mutableStateOf(false) }
         Box(
-            modifier = modifier.size(size).clip(CircleShape).background(if (loaded_pp) Color.White else bg_fb),
+            modifier = modifier.size(size).clip(CircleShape).background(if (loaded_pp) Color.Transparent else bg_fb),
             contentAlignment = Alignment.Center,
         ) {
             if (!loaded_pp) {
@@ -273,7 +273,7 @@ private fun AsterDomainAvatar(
     if (pic_url != null) {
         var loaded by remember(pic_url) { mutableStateOf(false) }
         Box(
-            modifier = modifier.size(size).clip(CircleShape).background(if (loaded) Color.White else Color(0xFF4F46E5)),
+            modifier = modifier.size(size).clip(CircleShape).background(if (loaded) Color.Transparent else Color(0xFF4F46E5)),
             contentAlignment = Alignment.Center,
         ) {
             if (!loaded) {


### PR DESCRIPTION
## What

Account avatars were not displaying in two places:

- **Account switcher dialog**: profile pictures are stored as base64 `data:` URIs, but the switcher passed the raw URI straight into Coil with no decode (unlike every other avatar renderer, which uses `decode_avatar_model()`), so it silently failed and fell back to initials.
- **Drawer header**: the `account_avatar` slot was hardcoded to the static `aster_favicon` logo and never rendered the current account's avatar.

Loaded profile pictures also lost their transparency, because the avatar background was set to white once loaded instead of transparent.

## Changes

- Account switcher now reuses the shared `SenderAvatar(profile_picture_url = ...)`, which decodes data URIs and handles fallback in one place (removes a duplicated `SubcomposeAsyncImage` block).
- `workspace_header` renders the current account avatar via `SenderAvatar` instead of the app logo.
- Loaded profile pictures use a transparent backing (matching `current_user_avatar`), preserving alpha; initials and external-domain favicon fallbacks keep their solid backing.

## Test

Built `fdroidDebug`, verified on-device: avatar shows in the account switcher and drawer header, transparency preserved.