### PR TITLE
fix(android): route drawer alias add to the real create dialog

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -873,8 +873,17 @@ private fun AsterNavHost() {
         composable(routes.settings_detail("text_size")) {
             AppearanceScreen(on_back = { back(); Unit })
         }
-        composable(routes.settings_detail("aliases")) {
-            AliasesScreen(on_back = { back(); Unit })
+        composable(
+            route = routes.settings_detail("aliases") + "?create={create}",
+            arguments = listOf(navArgument("create") {
+                type = NavType.BoolType
+                defaultValue = false
+            }),
+        ) { entry ->
+            AliasesScreen(
+                on_back = { back(); Unit },
+                open_create = entry.arguments?.getBoolean("create") ?: false,
+            )
         }
         composable(routes.settings_detail("subscriptions")) {
             MailingListsScreen(on_back = { back(); Unit })
@@ -1191,6 +1200,7 @@ private fun InboxWithDrawer(nav_controller: NavHostController) {
                         id == "subscriptions" -> { filter_kind = null; selected_folder = "subscriptions"; scope.launch { drawer_state.close() } }
                         id == "plan" -> nav_controller.navigate(routes.settings_detail("billing"))
                         id == "aliases_settings" -> nav_controller.navigate(routes.settings_detail("aliases"))
+                        id == "aliases_create" -> nav_controller.navigate(routes.settings_detail("aliases") + "?create=true")
                         id == "referral" -> nav_controller.navigate(routes.settings_detail("referral"))
                         id in mail_folder_ids -> { filter_kind = null; selected_folder = id; scope.launch { drawer_state.close() } }
                         else -> { filter_kind = null; selected_folder = id; scope.launch { drawer_state.close() } }

--- a/app/src/main/kotlin/org/astermail/android/ui/drawer/drawer_content.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/drawer/drawer_content.kt
@@ -298,7 +298,6 @@ fun DrawerContent(
 
     var show_create_folder by remember { mutableStateOf(false) }
     var show_create_label by remember { mutableStateOf(false) }
-    var show_create_alias by remember { mutableStateOf(false) }
 
     val folder_items = api_folder_items.ifEmpty { default_folder_items }
     val label_items = api_label_items.ifEmpty { default_label_items }
@@ -525,7 +524,10 @@ fun DrawerContent(
                     on_sidebar_toggle("sidebar_aliases_collapsed", !aliases_expanded)
                 },
                 show_add = true,
-                on_add = { show_create_alias = true },
+                on_add = {
+                    on_select("aliases_create")
+                    on_close()
+                },
             )
             androidx.compose.animation.AnimatedVisibility(
                 visible = aliases_expanded,
@@ -695,18 +697,6 @@ fun DrawerContent(
         )
     }
 
-    if (show_create_alias) {
-        create_item_dialog(
-            title = stringResource(R.string.create_alias),
-            placeholder = stringResource(R.string.alias_placeholder),
-            on_dismiss = { show_create_alias = false },
-            on_create = { _ ->
-                show_create_alias = false
-                on_select("aliases_settings")
-                on_close()
-            },
-        )
-    }
 }
 
 @Composable

--- a/app/src/main/kotlin/org/astermail/android/ui/settings/detail/aliases_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/settings/detail/aliases_screen.kt
@@ -112,6 +112,7 @@ private fun tab_labels_computed(): List<String> = listOf(
 fun AliasesScreen(
     on_back: () -> Unit,
     on_open: (id: String) -> Unit = {},
+    open_create: Boolean = false,
 ) {
     val vm: SettingsViewModel = hiltViewModel()
     val state by vm.state.collectAsStateWithLifecycle()
@@ -141,6 +142,10 @@ fun AliasesScreen(
     LaunchedEffect(Unit) {
         vm.load_aliases()
         vm.load_domains()
+    }
+
+    LaunchedEffect(open_create) {
+        if (open_create) show_create_alias = true
     }
 
     LaunchedEffect(selected_tab) {


### PR DESCRIPTION
## What

The Aliases section "+" in the navigation drawer opened a generic single-field dialog (the same one used for folders). On Save it **discarded the typed text and just navigated to Settings** without creating anything - inconsistent with, and far less capable than, the real create-alias dialog in Settings (username + domain picker + generate-random).

## Changes

- Drawer "+" now routes straight to **Settings -> Aliases** and opens its real create dialog, instead of the no-op stub.
- Added an optional `create` nav arg on the aliases route; `AliasesScreen` opens its create dialog when `open_create` is true.
- Removed the dead single-field alias dialog from the drawer (the shared `create_item_dialog` stays for folder creation).

Single source of truth for alias creation; no behaviour duplicated in the drawer.

## Test

Built `fdroidDebug`. Full on-device verification pending alongside the other open alias fixes.