### PR TITLE
fix(android): show custom domain aliases in drawer and settings

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -1049,6 +1049,7 @@ private fun InboxWithDrawer(nav_controller: NavHostController) {
         settings_vm.load_labels()
         settings_vm.load_tags()
         settings_vm.load_aliases()
+        settings_vm.load_custom_domain_addresses()
         settings_vm.load_preferences()
         mail_vm.load_stats()
     }
@@ -1170,6 +1171,13 @@ private fun InboxWithDrawer(nav_controller: NavHostController) {
             drawer_alias_item(
                 id = alias.id,
                 address = alias.address,
+            )
+        } + settings_state.custom_domain_addresses
+        .filter { !looks_encrypted(it.encrypted_local_part) }
+        .map { addr ->
+            drawer_alias_item(
+                id = addr.id,
+                address = addr.address,
             )
         }
 

--- a/app/src/main/kotlin/org/astermail/android/ui/settings/detail/aliases_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/settings/detail/aliases_screen.kt
@@ -141,6 +141,7 @@ fun AliasesScreen(
     LaunchedEffect(Unit) {
         vm.load_aliases()
         vm.load_domains()
+        vm.load_custom_domain_addresses()
     }
 
     LaunchedEffect(selected_tab) {
@@ -350,6 +351,44 @@ private fun aliases_tab(
                     }
                 }
                 if (idx < state.aliases.lastIndex) AsterDivider(modifier = Modifier)
+            }
+        }
+    }
+
+    if (state.custom_domain_addresses.isNotEmpty()) {
+        v_gap(AsterSpacing.md)
+        Text(
+            text = stringResource(R.string.custom_domains),
+            color = colors.text_tertiary,
+            fontSize = 13.sp,
+        )
+        v_gap(AsterSpacing.sm)
+        AsterCard(modifier = Modifier.fillMaxWidth()) {
+            state.custom_domain_addresses.forEachIndexed { idx, addr ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = AsterSpacing.lg, vertical = AsterSpacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = addr.address,
+                        color = if (addr.decryption_failed) colors.text_muted else colors.text_primary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.weight(1f),
+                    )
+                    AsterIconButton(
+                        icon = Icons.Outlined.ContentCopy,
+                        content_description = "Copy",
+                        onClick = {
+                            val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            cm.setPrimaryClip(ClipData.newPlainText("alias", addr.address))
+                            android.widget.Toast.makeText(context, "Copied", android.widget.Toast.LENGTH_SHORT).show()
+                        },
+                    )
+                }
+                if (idx < state.custom_domain_addresses.lastIndex) AsterDivider(modifier = Modifier)
             }
         }
     }


### PR DESCRIPTION
## What

Addresses on custom domains were invisible in the app's alias UI. `load_custom_domain_addresses()` was only called in the compose screen, so custom-domain addresses appeared solely in the "From" picker - never in the navigation drawer's Aliases section nor in Settings -> Aliases.

## Changes

- Load custom-domain addresses on drawer init and merge them into the drawer Aliases list (navigable like regular aliases).
- Settings -> Aliases tab: load and render them in a read-only **Custom domains** card (address + copy) below the regular aliases.

Read-only because there is no per-address API (only domain-level add/delete/verify), matching how the compose "From" picker treats them.

## Test

Built `fdroidDebug`, installed on-device; custom-domain addresses now appear in both places. Logcat clean (no decrypt/alias/crash errors). Marked draft pending full manual verification.