### PR TITLE
fix(fdroid): make native build reproducible (trim-paths, drop vcsInfo)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ android {
                 signingConfig = signingConfigs.getByName("release")
             }
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            vcsInfo { include = false }
         }
     }
 

--- a/rust/aster-crypto-ffi/Cargo.toml
+++ b/rust/aster-crypto-ffi/Cargo.toml
@@ -30,3 +30,4 @@ jni = { version = "0.21", default-features = false }
 
 [profile.release]
 strip = true
+trim-paths = "all"


### PR DESCRIPTION
Two-line change so the fdroid flavor can byte-reproduce under F-Droid Track A.

**Changes**
- rust/aster-crypto-ffi/Cargo.toml: add trim-paths = "all" to [profile.release]. Stable since Rust 1.81; remaps workspace + registry paths so libaster_crypto_ffi.so is location-independent (currently the reference .so bakes in /home/runner/.cargo/registry/... GitHub-runner paths, which differ from F-Droid build paths).
- app/build.gradle.kts release buildType: add vcsInfo { include = false } to drop META-INF/version-control-info.textproto, removing the embedded-commit mismatch.

**Why**
F-Droid rebuilds the tag from source and compares byte-for-byte against the developer-signed reference APK. The compare currently fails on exactly these two reference-side diffs.

**Testing**
Compile-checked only. trim-paths is the high-confidence cause of the .so path diff but is NOT yet proven the sole cause: that requires cutting a new reference APK built WITH this change and confirming it reproduces under F-Droid (needs the release signing key, maintainer-side). After merge: cut a tag including this commit, rebuild + re-sign the fdroid reference with the pinned toolchain (Rust 1.92.0, NDK r27c, cargo-ndk 4.1.2), then re-run fdroiddata MR !40463.