### PR TITLE
fix(fdroid): remap build paths in native lib for reproducibility

### DIFF
--- a/rust/aster-crypto-ffi/scripts/build_android.sh
+++ b/rust/aster-crypto-ffi/scripts/build_android.sh
@@ -28,6 +28,10 @@ fi
 
 mkdir -p "$android_jni_dir"
 
+cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+rust_sysroot="$(rustc --print sysroot)"
+export RUSTFLAGS="--remap-path-prefix=${cargo_home}=/cargo --remap-path-prefix=${repo_root}=/build --remap-path-prefix=${rust_sysroot}=/rust ${RUSTFLAGS:-}"
+
 cargo ndk \
     -t arm64-v8a \
     -t armeabi-v7a \


### PR DESCRIPTION
## Summary

Makes the `libaster_crypto_ffi.so` native build path-independent so the fdroid flavor is byte-reproducible across build machines, on **stable** cargo.

`build_android.sh` now exports `RUSTFLAGS=--remap-path-prefix` for three machine-specific roots before `cargo ndk ... build`:
- `$CARGO_HOME` -> `/cargo`
- repo root -> `/build`
- `rustc --print sysroot` -> `/rust`

### Background

The previous attempt used `[profile.release] trim-paths = "all"`, which broke CI because `trim-paths` is a nightly-only Cargo profile key (not stabilized as of Cargo 1.92.0, confirmed still nightly on 1.96.0). It was reverted in 96e36a6. Without it, dependency source paths from the build machine are embedded in the stripped `.so` (panic-location strings in `.rodata` survive `strip = true`), e.g. `/home/runner/.cargo/registry/src/.../argon2-0.5.3/src/lib.rs`. F-Droid builds under a different root (`/home/vagrant/...`), so the bytes differ and the reproducibility compare fails.

`--remap-path-prefix` is the stable equivalent: both the reference build and the F-Droid buildserver run this same script, so both normalize to the constant `/cargo`, `/build`, `/rust` prefixes regardless of the actual build directory, yielding identical bytes.

This pairs with the already-landed `vcsInfo { include = false }` (f574e6d) which removed the other repro diff (`version-control-info.textproto`).

## Testing

Verified on GitHub Actions (the `build` workflow), not on-device:
- `build native crypto from source` passes - the extra `RUSTFLAGS` does not interfere with cargo-ndk's linker setup.
- `assembleFullRelease assembleFdroidRelease` passes.
- The packaged fdroid-flavor `.so` for all three ABIs (arm64-v8a, armeabi-v7a, x86_64) contains zero `/home/runner`, `.cargo`, or `.rustup` paths after the change; the registry paths read `/cargo/registry/...` instead.

Not yet done: a full byte-for-byte compare against an F-Droid buildserver build (requires a maintainer-signed fdroid reference APK for the current tag).
