### PR TITLE
fix(fdroid): pin NDK for cargo-ndk and preserve signing alignment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,10 @@ jobs:
       - name: install NDK r27c
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;27.2.12479018" >/dev/null
-          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          ndk="$ANDROID_HOME/ndk/27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ndk" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_LATEST_HOME=$ndk" >> "$GITHUB_ENV"
       - name: install cargo-ndk
         run: cargo install cargo-ndk --locked --version 4.1.2
       - name: build native crypto from source

--- a/.github/workflows/release_fdroid.yml
+++ b/.github/workflows/release_fdroid.yml
@@ -22,7 +22,10 @@ jobs:
       - name: install NDK r27c
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;27.2.12479018" >/dev/null
-          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          ndk="$ANDROID_HOME/ndk/27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ndk" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_LATEST_HOME=$ndk" >> "$GITHUB_ENV"
 
       - name: install cargo-ndk
         run: cargo install cargo-ndk --locked --version 4.1.2

--- a/docs/fdroid_setup_for_maintainer.md
+++ b/docs/fdroid_setup_for_maintainer.md
@@ -104,13 +104,21 @@ public CI):
 
 1. Run the `release_fdroid` workflow on the tag; download the `fdroid-unsigned`
    artifact (`app-fdroid-release-unsigned.apk`).
-2. On the release machine, sign it locally:
+2. On the release machine, sign it locally. Do **not** run `zipalign`: the
+   unsigned APK is already aligned by AGP exactly as F-Droid's buildserver
+   produces it, and `apksigner` from build-tools 35+ re-aligns on its own by
+   default (rewriting the padding into `0xd935` alignment extra fields), which
+   changes the bytes covered by the v2/v3 signature and breaks the reproducible
+   compare. Pass `--alignment-preserved` so the AGP layout is kept and the
+   signature transplant matches the from-source build:
    ```bash
-   zipalign -p -f 4 app-fdroid-release-unsigned.apk aligned.apk
    apksigner sign --ks keystore/aster-mail-upload-v3.jks \
-     --ks-key-alias aster-mail --out Aster-Mail-fdroid-<version>.apk aligned.apk
+     --ks-key-alias aster-mail --alignment-preserved \
+     --out Aster-Mail-fdroid-<version>.apk app-fdroid-release-unsigned.apk
    apksigner verify --print-certs Aster-Mail-fdroid-<version>.apk
    ```
+   `--alignment-preserved` requires build-tools >= 35; build-tools 34's
+   `apksigner` never re-aligns, so it also works there without the flag.
    The cert SHA-256 must be `88b0a8a6...0977` (matches `AllowedAPKSigningKeys`).
 3. Attach `Aster-Mail-fdroid-<version>.apk` to the GitHub Release for that tag.
 


### PR DESCRIPTION
## What

Closes the remaining two reproducibility gaps for the F-Droid Track A
(developer-signed, byte-reproducible) submission, on top of the path-remap fix
in #17:

1. **NDK selection in CI** (`build.yml`, `release_fdroid.yml`). The NDK step set
   only `ANDROID_NDK_ROOT`, but `cargo-ndk` resolves the NDK from
   `ANDROID_NDK_HOME` / `ANDROID_NDK_LATEST_HOME` **first**. The GitHub runner
   pre-sets those to its bundled NDK (r27d, clang/LLD 18.0.4), so the
   `ndk;27.2.12479018` (r27c, 18.0.3) we install was ignored and the native libs
   were built with the wrong toolchain. Different LLVM codegen + a different
   `.note.android.ident` stamp made `libaster_crypto_ffi.so` non-reproducible
   against an r27c F-Droid build. Fix: set all three env vars to the r27c path.

2. **Maintainer signing step** (`docs/fdroid_setup_for_maintainer.md`). The
   documented Track A flow ran `zipalign -p -f 4` and then plain `apksigner
   sign`. AGP already aligns the unsigned APK exactly as F-Droid's buildserver
   produces it; `apksigner` from build-tools 35+ also re-aligns by default,
   rewriting padding into `0xd935` alignment extra fields. Either re-align
   changes the bytes covered by the v2/v3 signature, so when F-Droid transplants
   the signature onto its from-source build the digests no longer match
   (`CHUNKED_SHA512 digest mismatch`). Fix: drop `zipalign` and sign with
   `apksigner --alignment-preserved`.

## Testing

Validated end-to-end on a fork before opening this PR. Using a fork copy of
`release_fdroid.yml` (signed with a throwaway fork key) and the fdroiddata MR
repointed at the fork, F-Droid's GitLab buildserver pipeline built from source
and ran the reproducible compare:

- With only `ANDROID_NDK_ROOT` set: the three `libaster_crypto_ffi.so` differed
  (247 bytes), everything else reproducible. After pinning all three NDK env
  vars to r27c, the from-source `.so` is byte-identical to the reference.
- With plain `apksigner`: signature transplant failed with the
  `CHUNKED_SHA512` mismatch above; the only diff was the `0xd935` alignment
  extra fields (all 331 non-`META-INF` entries otherwise byte-identical). With
  `--alignment-preserved` the reference matches the buildserver layout exactly
  and the pipeline's `fdroid build` job passes (`successfully verified`,
  reproducible-APK check fired).

These workflow/doc changes are reviewed-and-built on the fork's CI; the upstream
release-signing step (2) is performed by the maintainer locally and is not run
here. `build.yml` references no secrets and builds unsigned (`ASTER_UNSIGNED=1`).
