### PR TITLE
fix(android): device-side security hardening

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
         <receiver
             android:name=".notifications.BootReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />

--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -200,7 +200,10 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun enforce_secure_flag() {
-        if (LockdownStore.is_enabled(applicationContext)) {
+        val app_lock_configured = runCatching {
+            org.astermail.android.security.AppLockStore(applicationContext).is_configured()
+        }.getOrDefault(false)
+        if (LockdownStore.is_enabled(applicationContext) || app_lock_configured) {
             window.setFlags(
                 android.view.WindowManager.LayoutParams.FLAG_SECURE,
                 android.view.WindowManager.LayoutParams.FLAG_SECURE,

--- a/app/src/main/kotlin/org/astermail/android/auth/AuthRepository.kt
+++ b/app/src/main/kotlin/org/astermail/android/auth/AuthRepository.kt
@@ -530,6 +530,7 @@ class AuthRepository @Inject constructor(
 
         mail_repository.clear_caches()
         database.decrypted_mail_dao().clear_all()
+        session_key_store.get_user_email()?.let { trusted_device_store.clear(it) }
 
         current_password_hash.fill(0)
         new_password_hash.fill(0)
@@ -692,6 +693,7 @@ class AuthRepository @Inject constructor(
             ),
         )
         val current_id = session_key_store.get_user_id()
+        val current_email = session_key_store.get_user_email()
         token_store.clear()
         api_client.invalidate_bearer_cache()
         session_key_store.clear()
@@ -707,6 +709,7 @@ class AuthRepository @Inject constructor(
             org.astermail.android.mail.AsterProfileResolverHolder.shared?.clear()
         }
         database.decrypted_mail_dao().clear_all()
+        current_email?.let { trusted_device_store.clear(it) }
         if (current_id != null) {
             account_store.remove(current_id)
             runCatching { session_snapshot_store.remove(current_id) }

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/mail_detail_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/mail_detail_screen.kt
@@ -1889,7 +1889,11 @@ private fun raw_source_dialog(
                     label = stringResource(R.string.detail_raw_source_copy),
                     onClick = {
                         val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as? android.content.ClipboardManager
-                        clipboard?.setPrimaryClip(android.content.ClipData.newPlainText("raw_source", headers + "\n" + body_text))
+                        val clip = android.content.ClipData.newPlainText("raw_source", headers + "\n" + body_text)
+                        clip.description.extras = android.os.PersistableBundle().apply {
+                            putBoolean("android.content.extra.IS_SENSITIVE", true)
+                        }
+                        clipboard?.setPrimaryClip(clip)
                         Toast.makeText(context, context.getString(R.string.detail_raw_source_copied), Toast.LENGTH_SHORT).show()
                     },
                 )
@@ -3465,6 +3469,24 @@ private fun sanitize_filename(raw: String): String {
     return cleaned.ifBlank { "attachment" }.take(200)
 }
 
+private fun safe_view_mime(filename: String, declared: String): String {
+    val ext = filename.substringAfterLast('.', "").lowercase()
+    val resolved = if (ext.isNotBlank()) {
+        android.webkit.MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+    } else {
+        null
+    }
+    val mime = resolved ?: declared.ifBlank { "application/octet-stream" }
+    val blocked = setOf(
+        "application/vnd.android.package-archive",
+        "application/x-msdownload",
+        "application/x-executable",
+        "application/x-elf",
+        "application/x-sh",
+    )
+    return if (mime.lowercase() in blocked) "application/octet-stream" else mime
+}
+
 private fun save_attachment_to_storage(
     context: android.content.Context,
     attachment: MessageAttachment,
@@ -3609,7 +3631,7 @@ private fun attachment_preview_dialog(
                     content_description = stringResource(R.string.open_with),
                     onClick = {
                         try {
-                            val mime = attachment.content_type.ifBlank { "application/octet-stream" }
+                            val mime = safe_view_mime(attachment.filename, attachment.content_type)
                             val values = ContentValues().apply {
                                 put(MediaStore.Downloads.DISPLAY_NAME, sanitize_filename(attachment.filename))
                                 put(MediaStore.Downloads.MIME_TYPE, mime)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Device-side security hardening for the Android client. All changes are local to the app; no protocol, crypto-interop, or server contract is altered.

## Changes
- FLAG_SECURE is now applied when an app-lock is configured (previously only under Lockdown mode), blocking recents-thumbnail and screenshot capture of decrypted content for users who opt into app-lock. Default users are unaffected.
- Trusted-device token is cleared on account deletion and password change.
- Raw-source clipboard copy sets `IS_SENSITIVE` (consistent with the app's other copy sites).
- Attachment "open with" derives the MIME type from the file extension and neutralizes installable/executable types, instead of trusting the sender-supplied content type.
- `BootReceiver` is no longer exported (protected system broadcasts are still delivered).
- Gradle wrapper distribution is pinned via `distributionSha256Sum`.

## Verification
- `:app:testFullDebugUnitTest` passes.
- `full` and `fdroid` flavors compile clean.
- Gradle wrapper re-validated against the pinned checksum.