### PR TITLE
fix(android): six verified reliability/privacy bug fixes (0.6.89)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "org.astermail.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 97
-        versionName = "0.6.88"
+        versionCode = 98
+        versionName = "0.6.89"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/src/main/kotlin/org/astermail/android/auth/AuthRepository.kt
+++ b/app/src/main/kotlin/org/astermail/android/auth/AuthRepository.kt
@@ -539,7 +539,7 @@ class AuthRepository @Inject constructor(
         )
 
         response.csrf_token?.let { api_client.set_csrf(it) }
-        response.access_token?.let { token_store.save(it, it) }
+        response.access_token?.let { token_store.save(it, token_store.refresh_token ?: it) }
 
         mail_repository.clear_caches()
         database.decrypted_mail_dao().clear_all()

--- a/app/src/main/kotlin/org/astermail/android/mail/MailRepository.kt
+++ b/app/src/main/kotlin/org/astermail/android/mail/MailRepository.kt
@@ -182,7 +182,6 @@ class MailRepository @Inject constructor(
     )
     private val _pending_undo_send = kotlinx.coroutines.flow.MutableStateFlow<PendingUndoSend?>(null)
     val pending_undo_send: kotlinx.coroutines.flow.StateFlow<PendingUndoSend?> = _pending_undo_send
-    private val pending_send_job_ref = java.util.concurrent.atomic.AtomicReference<kotlinx.coroutines.Job?>(null)
     private val _send_result_events = kotlinx.coroutines.flow.MutableSharedFlow<Result<Unit>>(extraBufferCapacity = 8)
     val send_result_events: kotlinx.coroutines.flow.SharedFlow<Result<Unit>> = _send_result_events
 
@@ -204,13 +203,12 @@ class MailRepository @Inject constructor(
         draft_id: String? = null,
         on_completed: ((Result<Unit>) -> Unit)? = null,
     ) {
-        pending_send_job_ref.getAndSet(null)?.cancel()
         val delay_ms = undo_seconds.coerceAtLeast(1) * 1000L
         val canceled_flag = java.util.concurrent.atomic.AtomicBoolean(false)
-        val self_ref = java.util.concurrent.atomic.AtomicReference<kotlinx.coroutines.Job?>(null)
+        val pending_ref = java.util.concurrent.atomic.AtomicReference<PendingUndoSend?>(null)
         val job = app_scope.launch {
             kotlinx.coroutines.delay(delay_ms)
-            _pending_undo_send.value = null
+            pending_ref.get()?.let { _pending_undo_send.compareAndSet(it, null) }
             if (!canceled_flag.get()) {
                 val result = send_email(
                     to = to,
@@ -234,11 +232,8 @@ class MailRepository @Inject constructor(
                 _send_result_events.tryEmit(unit_result)
                 on_completed?.invoke(unit_result)
             }
-            self_ref.get()?.let { pending_send_job_ref.compareAndSet(it, null) }
         }
-        self_ref.set(job)
-        pending_send_job_ref.set(job)
-        _pending_undo_send.value = PendingUndoSend(
+        val pending = PendingUndoSend(
             started_at_ms = System.currentTimeMillis(),
             duration_ms = delay_ms,
             draft_id = draft_id?.takeIf { it.isNotBlank() },
@@ -253,10 +248,11 @@ class MailRepository @Inject constructor(
             undo = {
                 canceled_flag.set(true)
                 job.cancel()
-                pending_send_job_ref.compareAndSet(job, null)
-                _pending_undo_send.value = null
+                pending_ref.get()?.let { _pending_undo_send.compareAndSet(it, null) }
             },
         )
+        pending_ref.set(pending)
+        _pending_undo_send.value = pending
     }
 
     fun clear_caches() {
@@ -1540,6 +1536,7 @@ class MailRepository @Inject constructor(
         cc: List<String> = emptyList(),
         bcc: List<String> = emptyList(),
         scheduled_at: String,
+        sender_alias_hash: String? = null,
     ): Result<String> = runCatching {
         val is_external = to.any { !it.endsWith("@astermail.org") && !it.endsWith("@aster.cx") } ||
             cc.any { !it.endsWith("@astermail.org") && !it.endsWith("@aster.cx") } ||
@@ -1571,23 +1568,16 @@ class MailRepository @Inject constructor(
         val recipients_nonce_bytes = derive_nonce(base_nonce, 0x02)
 
         val envelope_obj = org.json.JSONObject().apply {
+            put("to_recipients", org.json.JSONArray(to))
+            put("cc_recipients", org.json.JSONArray(cc))
+            put("bcc_recipients", org.json.JSONArray(bcc))
             put("subject", subject)
-            put("body_text", "")
-            put("body_html", body_html)
+            put("body", body_html)
+            put("scheduled_at", scheduled_at)
             put("from", org.json.JSONObject().apply {
                 put("name", sender_display_name.orEmpty())
                 put("email", sender_email.orEmpty())
             })
-            put("to", org.json.JSONArray().apply {
-                to.forEach { put(org.json.JSONObject().apply { put("name", ""); put("email", it) }) }
-            })
-            put("cc", org.json.JSONArray().apply {
-                cc.forEach { put(org.json.JSONObject().apply { put("name", ""); put("email", it) }) }
-            })
-            put("bcc", org.json.JSONArray().apply {
-                bcc.forEach { put(org.json.JSONObject().apply { put("name", ""); put("email", it) }) }
-            })
-            put("sent_at", scheduled_at)
         }
 
         val encrypted_envelope = encrypt_field(envelope_obj.toString(), envelope_nonce_bytes)
@@ -1618,6 +1608,7 @@ class MailRepository @Inject constructor(
                 is_external = is_external,
                 ephemeral_key = ephemeral_key_b64,
                 base_nonce = android.util.Base64.encodeToString(base_nonce, android.util.Base64.NO_WRAP),
+                sender_alias_hash = sender_alias_hash,
             ),
         )
         response.id ?: throw IllegalStateException("no scheduled item id returned")

--- a/app/src/main/kotlin/org/astermail/android/mail/MailViewModel.kt
+++ b/app/src/main/kotlin/org/astermail/android/mail/MailViewModel.kt
@@ -132,6 +132,7 @@ class MailViewModel @Inject constructor(
     private var inbox_load_job: Job? = null
     private var silent_revalidate_job: Job? = null
     private var refresh_job: Job? = null
+    private var account_generation = 0
     private val star_overrides = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
     private val pin_overrides = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
     private val read_overrides = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
@@ -189,8 +190,10 @@ class MailViewModel @Inject constructor(
     }
 
     fun reset_for_account_switch() {
+        account_generation++
         inbox_load_job?.cancel()
         silent_revalidate_job?.cancel()
+        refresh_job?.cancel()
         folder_cache.clear()
         folder_cache_time.clear()
         star_overrides.clear()
@@ -1365,6 +1368,7 @@ class MailViewModel @Inject constructor(
     fun refresh() {
         val folder = _inbox_state.value.current_folder
         if (_inbox_state.value.is_refreshing) return
+        val gen = account_generation
         folder_cache.remove(folder)
         folder_cache_time.remove(folder)
         _inbox_state.update { it.copy(is_refreshing = true) }
@@ -1378,6 +1382,7 @@ class MailViewModel @Inject constructor(
                     fetch_for_folder(folder).getOrThrow()
                 }
             }
+            if (account_generation != gen) return@launch
             if (_inbox_state.value.current_folder != folder) {
                 _inbox_state.update { it.copy(is_refreshing = false) }
                 return@launch
@@ -1561,6 +1566,7 @@ class MailViewModel @Inject constructor(
         sender_email: String? = null,
         sender_display_name: String? = null,
         scheduled_at: String,
+        sender_alias_hash: String? = null,
     ): Result<String> {
         return repository.schedule_email(
             subject = subject,
@@ -1571,6 +1577,7 @@ class MailViewModel @Inject constructor(
             cc = cc,
             bcc = bcc,
             scheduled_at = scheduled_at,
+            sender_alias_hash = sender_alias_hash,
         )
     }
 

--- a/app/src/main/kotlin/org/astermail/android/notifications/MailPollingWorker.kt
+++ b/app/src/main/kotlin/org/astermail/android/notifications/MailPollingWorker.kt
@@ -138,18 +138,20 @@ class MailPollingWorker(
         val cached_inbox = prefs.getInt(KEY_CACHED_INBOX, new_inbox)
         val last_notified_inbox = prefs.getInt(KEY_LAST_NOTIFIED_INBOX, -1)
 
-        if (has_baseline && new_inbox > cached_inbox && new_unread > 0 && new_inbox != last_notified_inbox) {
-            if (!is_quiet_hours_now(context)) {
-                val arrived = (new_inbox - cached_inbox).coerceAtMost(new_unread)
-                notify_for_new_mail(arrived)
-                prefs.edit().putInt(KEY_LAST_NOTIFIED_INBOX, new_inbox).apply()
-            }
+        val has_pending_new_mail = has_baseline && new_inbox > cached_inbox &&
+            new_unread > 0 && new_inbox != last_notified_inbox
+        val suppressed_by_quiet_hours = has_pending_new_mail && is_quiet_hours_now(context)
+        if (has_pending_new_mail && !suppressed_by_quiet_hours) {
+            val arrived = (new_inbox - cached_inbox).coerceAtMost(new_unread)
+            notify_for_new_mail(arrived)
+            prefs.edit().putInt(KEY_LAST_NOTIFIED_INBOX, new_inbox).apply()
         }
 
-        prefs.edit()
-            .putInt(KEY_CACHED_UNREAD, new_unread)
-            .putInt(KEY_CACHED_INBOX, new_inbox)
-            .apply()
+        val editor = prefs.edit().putInt(KEY_CACHED_UNREAD, new_unread)
+        if (!suppressed_by_quiet_hours) {
+            editor.putInt(KEY_CACHED_INBOX, new_inbox)
+        }
+        editor.apply()
         schedule_next(context)
         return Result.success()
     }

--- a/app/src/main/kotlin/org/astermail/android/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/astermail/android/settings/SettingsViewModel.kt
@@ -210,6 +210,8 @@ class SettingsViewModel @Inject constructor(
     @Volatile private var default_signature_is_html: Boolean = false
     private var load_preferences_job: kotlinx.coroutines.Job? = null
     private var save_preferences_job: kotlinx.coroutines.Job? = null
+    private var prefs_load_succeeded = false
+    private var account_uses_encrypted_prefs = false
 
     fun load_profile() {
         viewModelScope.launch {
@@ -1494,6 +1496,7 @@ class SettingsViewModel @Inject constructor(
                 val enc = response.encrypted_preferences
                 val nonce = response.preferences_nonce
                 val has_encrypted = !enc.isNullOrBlank() && !nonce.isNullOrBlank()
+                account_uses_encrypted_prefs = has_encrypted
 
                 if (has_encrypted) {
                     val identity_key = await_identity_key()
@@ -1511,6 +1514,7 @@ class SettingsViewModel @Inject constructor(
                         null
                     }
                     if (decrypted != null) {
+                        prefs_load_succeeded = true
                         _state.value = _state.value.copy(preferences = decrypted, is_loading = false)
                     } else {
                         _state.value = _state.value.copy(
@@ -1520,7 +1524,8 @@ class SettingsViewModel @Inject constructor(
                         )
                     }
                 } else {
-                    val prefs = try { preferences_api.get_preferences() } catch (_: Throwable) { UserPreferences() }
+                    val prefs = preferences_api.get_preferences()
+                    prefs_load_succeeded = true
                     _state.value = _state.value.copy(preferences = prefs, is_loading = false)
                 }
             } catch (t: Throwable) {
@@ -1760,6 +1765,13 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun save_preferences(prefs: UserPreferences) {
+        if (!prefs_load_succeeded) {
+            _state.value = _state.value.copy(
+                save_status = SaveStatus.ERROR,
+                error = context.getString(R.string.preferences_locked_retry),
+            )
+            return
+        }
         load_preferences_job?.cancel()
         save_preferences_job?.cancel()
         _state.value = _state.value.copy(preferences = prefs, save_status = SaveStatus.SAVING)
@@ -1769,6 +1781,12 @@ class SettingsViewModel @Inject constructor(
                 if (!identity_key.isNullOrBlank()) {
                     val request = encrypt_preferences(prefs, identity_key)
                     preferences_api.save_encrypted_preferences(request)
+                } else if (account_uses_encrypted_prefs) {
+                    _state.value = _state.value.copy(
+                        save_status = SaveStatus.ERROR,
+                        error = context.getString(R.string.preferences_locked_retry),
+                    )
+                    return@launch
                 } else {
                     preferences_api.save_preferences(prefs)
                 }

--- a/app/src/main/kotlin/org/astermail/android/ui/compose/compose_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/compose/compose_screen.kt
@@ -889,6 +889,12 @@ fun ComposeScreen(
         val (body_html, attachment_payloads, suppress_branding) = prepare_send_data()
 
         if (scheduled_send) {
+            if (attachment_payloads.isNotEmpty()) {
+                is_sending = false
+                send_lock.set(false)
+                send_error = context.getString(R.string.scheduled_send_no_attachments)
+                return
+            }
             scope.launch {
                 val scheduled_at = scheduled_at_iso ?: java.time.Instant.now().plus(java.time.Duration.ofHours(1)).toString()
                 val result = mail_vm.schedule_email(
@@ -900,6 +906,7 @@ fun ComposeScreen(
                     sender_email = from_alias,
                     sender_display_name = settings_state.user?.display_name,
                     scheduled_at = scheduled_at,
+                    sender_alias_hash = if (from_alias != user_email) alias_hash_map[from_alias]?.takeIf { it.isNotBlank() } else null,
                 )
                 result.fold(
                     onSuccess = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,6 +679,7 @@
     <string name="import_job_created">Import job started</string>
     <string name="import_file_too_large">File is too large (max 10 GiB)</string>
     <string name="attachment_too_large">\"%1$s\" is too large (max 25 MB)</string>
+    <string name="scheduled_send_no_attachments">Scheduled emails can\'t include attachments yet. Remove them or send now.</string>
     <string name="import_provider_gmail">Gmail</string>
     <string name="import_provider_outlook">Outlook</string>
     <string name="import_provider_yahoo">Yahoo</string>

--- a/app/src/test/kotlin/org/astermail/android/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/astermail/android/settings/SettingsViewModelTest.kt
@@ -1250,6 +1250,47 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `save_preferences refuses and never writes when an encrypted load did not succeed`() = runTest {
+        coEvery { preferences_api.get_encrypted_preferences() } returns
+            org.astermail.android.api.preferences.EncryptedPreferencesResponse(
+                encrypted_preferences = "blob",
+                preferences_nonce = "nonce",
+            )
+        every { session_key_store.get_identity_key() } returns "badkey"
+
+        val fresh_vm = SettingsViewModel(
+            auth_api = auth_api,
+            user_api = user_api,
+            settings_api = settings_api,
+            labels_api = labels_api,
+            family_api = family_api,
+            tags_api = tags_api,
+            preferences_api = preferences_api,
+            signatures_api = signatures_api,
+            ghost_alias_api = ghost_alias_api,
+            auto_forward_api = auto_forward_api,
+            developer_api = developer_api,
+            subscriptions_api = subscriptions_api,
+            recovery_email_api = recovery_email_api,
+            security_api = security_api,
+            encryption_api = encryption_api,
+            auth_repository = auth_repository,
+            session_key_store = session_key_store,
+            token_store = token_store,
+            account_store = account_store,
+            context = context,
+        )
+        advanceUntilIdle()
+
+        fresh_vm.save_preferences(UserPreferences(load_remote_images = true))
+        advanceUntilIdle()
+
+        assertEquals(SaveStatus.ERROR, fresh_vm.state.value.save_status)
+        coVerify(exactly = 0) { preferences_api.save_encrypted_preferences(any()) }
+        coVerify(exactly = 0) { preferences_api.save_preferences(any()) }
+    }
+
+    @Test
     fun `load_preferences error sets error message`() = runTest {
         coEvery { preferences_api.get_encrypted_preferences() } throws RuntimeException("prefs error")
 


### PR DESCRIPTION
Bug-hunt pass over the Android app. Six verified bugs fixed, each surgical, with a regression test added for the settings guard. Full unit suite green (627), emulator update vc97->vc98 clean.

- fix(auth): change_password wrote the access JWT into the refresh-token slot, forcing sign-out after every password change. Preserve the existing refresh token.
- fix(settings): save_preferences could plaintext-save (zero-access violation + permanent downgrade) when the key was transiently null, and could persist defaults over the user's real encrypted prefs after a decrypt-failure load. Added load-success + encryption guards; never plaintext-save an encrypted account. +regression test.
- fix(send): sending a second email within the first's undo window cancelled the first's pending job mid-delay, silently dropping it. Each send now proceeds independently.
- fix(compose): scheduled send silently dropped attachments (backend endpoint can't carry them). Now blocked with a clear message.
- fix(notifications): mail arriving during quiet hours was never notified (baseline advanced unconditionally). Keep the baseline until quiet hours end.
- fix(mail): a fast account switch let an in-flight refresh write account A's decrypted mail into account B. Cancel refresh on switch + generation guard.

chore(release): bump to 0.6.89 (vc98).