### PR TITLE
feat(debug): visible debug-build indicator with production hint

### DIFF
--- a/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -1,0 +1,148 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+package org.astermail.android.debugtools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.astermail.android.R
+import org.astermail.android.design.AsterMaterial
+
+private const val production_release_url = "https://github.com/Aster-Privacy/Aster-Mail/releases/"
+
+@Composable
+fun debug_build_banner() {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        if (expanded) {
+            debug_build_notice(
+                modifier = Modifier.align(Alignment.TopCenter),
+                on_collapse = { expanded = false },
+            )
+        } else {
+            debug_build_pill(
+                modifier = Modifier.align(Alignment.TopEnd),
+                on_expand = { expanded = true },
+            )
+        }
+    }
+}
+
+@Composable
+private fun debug_build_pill(modifier: Modifier, on_expand: () -> Unit) {
+    val colors = AsterMaterial.colors
+    Text(
+        text = stringResource(R.string.debug_banner_label),
+        color = colors.warning,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .clickable(onClick = on_expand)
+            .background(colors.bg_card.copy(alpha = 0.9f), RoundedCornerShape(50))
+            .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(50))
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+    )
+}
+
+@Composable
+private fun debug_build_notice(modifier: Modifier, on_collapse: () -> Unit) {
+    val colors = AsterMaterial.colors
+    val link_text = stringResource(R.string.debug_banner_link)
+    val body = stringResource(R.string.debug_banner_body, link_text)
+    val link_start = body.indexOf(link_text)
+
+    val annotated = buildAnnotatedString {
+        if (link_start < 0) {
+            append(body)
+        } else {
+            append(body.substring(0, link_start))
+            withLink(
+                LinkAnnotation.Url(
+                    url = production_release_url,
+                    styles = TextLinkStyles(
+                        style = SpanStyle(
+                            color = colors.accent_blue,
+                            textDecoration = TextDecoration.Underline,
+                        ),
+                    ),
+                ),
+            ) {
+                append(link_text)
+            }
+            append(body.substring(link_start + link_text.length))
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .widthIn(max = 420.dp)
+            .background(colors.bg_card, RoundedCornerShape(10.dp))
+            .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(10.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.debug_banner_label),
+            color = colors.warning,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.clickable(onClick = on_collapse),
+        )
+        Text(
+            text = annotated,
+            color = colors.text_secondary,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}

--- a/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -57,46 +58,44 @@ private const val production_release_url = "https://github.com/Aster-Privacy/Ast
 
 @Composable
 fun debug_build_banner() {
-    var expanded by remember { mutableStateOf(false) }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
             .padding(horizontal = 8.dp, vertical = 4.dp),
     ) {
-        if (expanded) {
-            debug_build_notice(
-                modifier = Modifier.align(Alignment.TopCenter),
-                on_collapse = { expanded = false },
-            )
-        } else {
-            debug_build_pill(
-                modifier = Modifier.align(Alignment.TopEnd),
-                on_expand = { expanded = true },
-            )
+        debug_build_pill_inline(modifier = Modifier.align(Alignment.TopEnd))
+    }
+}
+
+@Composable
+fun debug_build_pill_inline(modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    val colors = AsterMaterial.colors
+
+    Box(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.debug_banner_label),
+            color = colors.warning,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier
+                .clickable { expanded = true }
+                .background(colors.bg_card.copy(alpha = 0.9f), RoundedCornerShape(50))
+                .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(50))
+                .padding(horizontal = 8.dp, vertical = 3.dp),
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            debug_build_notice(on_collapse = { expanded = false })
         }
     }
 }
 
 @Composable
-private fun debug_build_pill(modifier: Modifier, on_expand: () -> Unit) {
-    val colors = AsterMaterial.colors
-    Text(
-        text = stringResource(R.string.debug_banner_label),
-        color = colors.warning,
-        fontSize = 10.sp,
-        fontWeight = FontWeight.Bold,
-        modifier = modifier
-            .clickable(onClick = on_expand)
-            .background(colors.bg_card.copy(alpha = 0.9f), RoundedCornerShape(50))
-            .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(50))
-            .padding(horizontal = 8.dp, vertical = 3.dp),
-    )
-}
-
-@Composable
-private fun debug_build_notice(modifier: Modifier, on_collapse: () -> Unit) {
+private fun debug_build_notice(on_collapse: () -> Unit) {
     val colors = AsterMaterial.colors
     val link_text = stringResource(R.string.debug_banner_link)
     val body = stringResource(R.string.debug_banner_body, link_text)
@@ -125,12 +124,10 @@ private fun debug_build_notice(modifier: Modifier, on_collapse: () -> Unit) {
     }
 
     Column(
-        modifier = modifier
-            .widthIn(max = 420.dp)
+        modifier = Modifier
+            .widthIn(max = 300.dp)
             .clickable(onClick = on_collapse)
-            .background(colors.bg_card, RoundedCornerShape(10.dp))
-            .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(10.dp))
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
     ) {
         Text(
             text = stringResource(R.string.debug_banner_label),

--- a/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.unit.sp
 import org.astermail.android.R
 import org.astermail.android.design.AsterMaterial
 
-private const val production_release_url = "https://github.com/Aster-Privacy/Aster-Mail/releases/"
+private const val production_release_url = "https://github.com/Aster-Privacy/Aster-Android/releases/"
 
 @Composable
 fun debug_build_banner() {

--- a/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/debug/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -127,6 +127,7 @@ private fun debug_build_notice(modifier: Modifier, on_collapse: () -> Unit) {
     Column(
         modifier = modifier
             .widthIn(max = 420.dp)
+            .clickable(onClick = on_collapse)
             .background(colors.bg_card, RoundedCornerShape(10.dp))
             .border(1.dp, colors.warning.copy(alpha = 0.5f), RoundedCornerShape(10.dp))
             .padding(horizontal = 12.dp, vertical = 10.dp),
@@ -136,7 +137,6 @@ private fun debug_build_notice(modifier: Modifier, on_collapse: () -> Unit) {
             color = colors.warning,
             fontSize = 10.sp,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.clickable(onClick = on_collapse),
         )
         Text(
             text = annotated,

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="debug_banner_label">DEBUG BUILD</string>
+    <string name="debug_banner_link">production build</string>
+    <string name="debug_banner_body">This is a debug build — it is intended for developers only, and may contain serious bugs. Please use the latest %1$s instead.</string>
+</resources>

--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
+import org.astermail.android.debugtools.debug_build_banner
 import org.astermail.android.security.AppLockViewModel
 import org.astermail.android.security.LockdownStore
 import org.astermail.android.ui.common.nav_anim_duration_ms
@@ -291,6 +292,7 @@ private fun AsterRoot() {
                     .background(colors.bg_primary),
             ) {
                 AsterNavHost()
+                debug_build_banner()
             }
         }
     }

--- a/app/src/main/kotlin/org/astermail/android/MainActivity.kt
+++ b/app/src/main/kotlin/org/astermail/android/MainActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
-import org.astermail.android.debugtools.debug_build_banner
 import org.astermail.android.security.AppLockViewModel
 import org.astermail.android.security.LockdownStore
 import org.astermail.android.ui.common.nav_anim_duration_ms
@@ -292,7 +291,6 @@ private fun AsterRoot() {
                     .background(colors.bg_primary),
             ) {
                 AsterNavHost()
-                debug_build_banner()
             }
         }
     }

--- a/app/src/main/kotlin/org/astermail/android/ui/auth/sign_in_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/auth/sign_in_screen.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.astermail.android.R
 import org.astermail.android.auth.AuthUiState
+import org.astermail.android.debugtools.debug_build_banner
 import org.astermail.android.auth.AuthViewModel
 import org.astermail.android.design.SquircleShape
 import org.astermail.android.design.AsterMaterial
@@ -359,6 +360,8 @@ fun SignInScreen(
                 Spacer(Modifier.height(AsterSpacing.xxl))
             }
         }
+
+        debug_build_banner()
     }
 }
 

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/inbox_screen.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/inbox_screen.kt
@@ -134,6 +134,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import org.astermail.android.R
+import org.astermail.android.debugtools.debug_build_pill_inline
 import org.astermail.android.design.SquircleShape
 import org.astermail.android.design.AsterMaterial
 import org.astermail.android.design.AsterSpacing
@@ -1177,6 +1178,8 @@ private fun inbox_top_bar(
                     }
                 }
             }
+            debug_build_pill_inline()
+            Spacer(Modifier.width(AsterSpacing.xs))
             AsterIconButton(
                 icon = Icons.Outlined.Settings,
                 content_description = stringResource(R.string.settings),

--- a/app/src/release/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/release/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -22,7 +22,12 @@
 package org.astermail.android.debugtools
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
 fun debug_build_banner() {
+}
+
+@Composable
+fun debug_build_pill_inline(modifier: Modifier = Modifier) {
 }

--- a/app/src/release/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
+++ b/app/src/release/kotlin/org/astermail/android/debugtools/debug_build_banner.kt
@@ -1,0 +1,28 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+package org.astermail.android.debugtools
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun debug_build_banner() {
+}


### PR DESCRIPTION
Adds a debug-build indicator so a developer running a debug APK can tell at a glance, and can find the production build.

**Placement**

- Sign-in screen: small `DEBUG BUILD` pill overlaid top-right.
- Signed in: the same pill inline in the inbox top bar, immediately left of the settings gear.
- Nowhere else - the indicator is deliberately not carried into the rest of the app.

Tapping the pill opens a short notice explaining the build is for developers only and linking to this repo's releases page. Tapping the notice, or anywhere outside it, collapses it; the link keeps its own tap.

An earlier revision rendered the pill as a global overlay on every screen, which covered the settings gear on the inbox. Hence the split placement.

**Production isolation**

The implementation lives in the `debug` source set, with a no-op twin of the same signature in `release`. Call sites in shared code therefore compile to empty composables in production rather than being guarded at runtime, so neither the banner code nor its strings enter a release build. Strings live in `app/src/debug/res/` and are not translated, being developer-facing only.

**Testing**

- `assembleFdroidDebug` and `assembleFdroidRelease` both build clean (0 Kotlin errors).
- Installed and exercised on a physical device (arm64, Android 15): pill confirmed visible on the sign-in screen and inline in the inbox bar without obscuring the gear; expand, collapse and link-tap all behave.
- Verified absent from production: decompressed `classes*.dex` from the release APK and grepped for `debugtools`, `debug_build` and the release URL - 0 hits each, against 19 / 52 / 1 hits in the debug APK as a control. Resource table checked separately with `aapt2 dump strings` - 0 matches.
- The final commit only retargets the link constant from the Mail repo to this one; it was not rebuilt or re-run on device, as it is a single string constant.
- No unit tests added; the change is presentation-only and debug-scoped.
