### PR TITLE
feat(mail): show receiving alias chip in inbox rows

### DIFF
--- a/app/src/main/kotlin/org/astermail/android/di/StorageModule.kt
+++ b/app/src/main/kotlin/org/astermail/android/di/StorageModule.kt
@@ -101,6 +101,7 @@ object StorageModule {
         builder.openHelperFactory(
             net.zetetic.database.sqlcipher.SupportOpenHelperFactory(db_passphrase(meta), null, false),
         )
+        builder.addMigrations(AsterDatabase.migration_4_5)
         builder.fallbackToDestructiveMigration()
         val db = builder.build()
         db.openHelper.writableDatabase

--- a/app/src/main/kotlin/org/astermail/android/mail/MailRepository.kt
+++ b/app/src/main/kotlin/org/astermail/android/mail/MailRepository.kt
@@ -137,6 +137,7 @@ data class InboxItem(
     val labels: List<String>,
     val tag_tokens: List<String> = emptyList(),
     val category: String = "primary",
+    val received_on: String? = null,
     val raw_item: MailItem,
 )
 
@@ -827,6 +828,9 @@ class MailRepository @Inject constructor(
             labels = item.labels?.mapNotNull { it.folder_token } ?: emptyList(),
             tag_tokens = item.tag_tokens ?: emptyList(),
             category = if (envelope != null) classify(envelope, meta) else "primary",
+            received_on = envelope?.raw_headers?.let {
+                org.astermail.android.ui.mail.resolve_inbox_received_on(it, get_user_email())
+            },
             raw_item = if (meta != null) item.copy(metadata = meta) else item,
         )
     }

--- a/app/src/main/kotlin/org/astermail/android/mail/MailViewModel.kt
+++ b/app/src/main/kotlin/org/astermail/android/mail/MailViewModel.kt
@@ -1886,5 +1886,6 @@ fun org.astermail.android.storage.search.DecryptedMailEntity.to_inbox_item(): In
     is_spam = is_spam,
     labels = if (labels.isBlank()) emptyList() else labels.split(","),
     category = category,
+    received_on = received_on,
     raw_item = org.astermail.android.api.mail.MailItem(id = id),
 )

--- a/app/src/main/kotlin/org/astermail/android/mail/SearchIndexManager.kt
+++ b/app/src/main/kotlin/org/astermail/android/mail/SearchIndexManager.kt
@@ -179,6 +179,7 @@ class SearchIndexManager @Inject constructor(
                 labels = item.labels.joinToString(","),
                 indexed_at = System.currentTimeMillis(),
                 category = item.category,
+                received_on = item.received_on,
             )
         }
         mutex.withLock {

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/delivered_to.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/delivered_to.kt
@@ -37,6 +37,15 @@ fun extract_delivered_to(raw_headers: List<Pair<String, String>>): String? {
         ?.lowercase()
 }
 
+fun resolve_inbox_received_on(
+    raw_headers: List<Pair<String, String>>,
+    user_email: String?,
+): String? {
+    val delivered = extract_delivered_to(raw_headers) ?: return null
+    val primary = user_email?.trim()?.lowercase()
+    return if (primary != null && delivered == primary) null else delivered
+}
+
 fun resolve_received_on_address(
     raw_headers: List<Pair<String, String>>,
     visible_addresses: List<String>,

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/email_row.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/email_row.kt
@@ -74,6 +74,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material.icons.outlined.AlternateEmail
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
@@ -217,6 +218,18 @@ fun EmailRow(
                             on_toggle_star()
                         },
                     )
+                }
+            }
+            email.received_on?.let {
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Spacer(Modifier.weight(1f))
+                    alias_chip(it)
                 }
             }
         }
@@ -411,7 +424,7 @@ fun ThreadInboxRow(
                     },
                 )
             }
-            if (thread.label_colors.isNotEmpty() || attachment_chips.isNotEmpty()) {
+            if (thread.label_colors.isNotEmpty() || attachment_chips.isNotEmpty() || email.received_on != null) {
                 Spacer(Modifier.height(4.dp))
                 Row(
                     modifier = Modifier
@@ -420,6 +433,7 @@ fun ThreadInboxRow(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Spacer(Modifier.weight(1f))
+                    email.received_on?.let { alias_chip(it) }
                     attachment_chips.forEach { chip ->
                         inbox_attachment_chip(chip)
                     }
@@ -467,6 +481,37 @@ private fun first_name(full: String): String {
     val trimmed = full.trim()
     val space = trimmed.indexOf(' ')
     return if (space > 0) trimmed.substring(0, space) else trimmed
+}
+
+@Composable
+private fun alias_chip(address: String) {
+    val colors = AsterMaterial.colors
+    val shape = SquircleShape(8.dp)
+    Row(
+        modifier = Modifier
+            .clip(shape)
+            .border(1.dp, colors.border_primary, shape)
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.AlternateEmail,
+            contentDescription = stringResource(R.string.received_on_label),
+            tint = colors.text_tertiary,
+            modifier = Modifier.size(11.dp),
+        )
+        Text(
+            text = address,
+            style = MaterialTheme.typography.labelSmall,
+            color = colors.text_secondary,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            fontFamily = inter_family,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/org/astermail/android/ui/mail/mock_email.kt
+++ b/app/src/main/kotlin/org/astermail/android/ui/mail/mock_email.kt
@@ -50,6 +50,7 @@ data class Email(
     val thread_message_count: Int = 1,
     val size_bytes: Long = 0,
     val category: String = "primary",
+    val received_on: String? = null,
 )
 
 data class ThreadRow(
@@ -1059,6 +1060,7 @@ fun inbox_item_to_email(
         label_names = matched_tags.map { it.encrypted_name },
         label_icons = matched_tags.map { it.encrypted_icon.orEmpty() },
         category = item.category,
+        received_on = item.received_on,
     )
 }
 

--- a/app/src/test/kotlin/org/astermail/android/mail/DeliveredToTest.kt
+++ b/app/src/test/kotlin/org/astermail/android/mail/DeliveredToTest.kt
@@ -22,6 +22,7 @@
 package org.astermail.android.mail
 
 import org.astermail.android.ui.mail.extract_delivered_to
+import org.astermail.android.ui.mail.resolve_inbox_received_on
 import org.astermail.android.ui.mail.resolve_received_on_address
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -94,5 +95,35 @@ class DeliveredToTest {
                 "myalias@astermail.org",
             ),
         )
+    }
+
+    @Test
+    fun inbox_surfaces_alias_when_not_primary() {
+        val headers = listOf("Delivered-To" to "shopping@aster.cx")
+        assertEquals(
+            "shopping@aster.cx",
+            resolve_inbox_received_on(headers, "me@astermail.org"),
+        )
+    }
+
+    @Test
+    fun inbox_suppresses_primary_address() {
+        val headers = listOf("Delivered-To" to "<Me@AsterMail.org>")
+        assertNull(resolve_inbox_received_on(headers, "me@astermail.org"))
+    }
+
+    @Test
+    fun inbox_surfaces_alias_when_primary_unknown() {
+        val headers = listOf("Delivered-To" to "shopping@aster.cx")
+        assertEquals(
+            "shopping@aster.cx",
+            resolve_inbox_received_on(headers, null),
+        )
+    }
+
+    @Test
+    fun inbox_returns_null_without_delivered_to() {
+        assertNull(resolve_inbox_received_on(emptyList(), "me@astermail.org"))
+        assertNull(resolve_inbox_received_on(listOf("To" to "a@b.c"), "me@astermail.org"))
     }
 }

--- a/core-storage/src/main/kotlin/org/astermail/android/storage/search/AsterDatabase.kt
+++ b/core-storage/src/main/kotlin/org/astermail/android/storage/search/AsterDatabase.kt
@@ -34,4 +34,12 @@ import org.astermail.android.storage.outbox.PendingSendEntity
 abstract class AsterDatabase : RoomDatabase() {
     abstract fun decrypted_mail_dao(): DecryptedMailDao
     abstract fun pending_send_dao(): PendingSendDao
+
+    companion object {
+        val migration_4_5 = object : androidx.room.migration.Migration(4, 5) {
+            override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE decrypted_mail_cache ADD COLUMN received_on TEXT")
+            }
+        }
+    }
 }

--- a/core-storage/src/main/kotlin/org/astermail/android/storage/search/DecryptedMailEntity.kt
+++ b/core-storage/src/main/kotlin/org/astermail/android/storage/search/DecryptedMailEntity.kt
@@ -44,4 +44,5 @@ data class DecryptedMailEntity(
     val labels: String,
     val indexed_at: Long,
     val category: String = "primary",
+    val received_on: String? = null,
 )


### PR DESCRIPTION
Shows which address (alias or received-on) an email arrived at, as a chip in inbox rows.